### PR TITLE
Add pagination to budgets query

### DIFF
--- a/TEL_ProjectBus/Program.cs
+++ b/TEL_ProjectBus/Program.cs
@@ -140,6 +140,7 @@ public class Program
 
             // Регистрация RequestClient
             x.AddRequestClient<GetBudgetByIdQuery>();
+            x.AddRequestClient<GetBudgetsByProjectIdQuery>();
             x.AddRequestClient<GetProjectsQuery>();
             x.AddRequestClient<GetProjectProfileQuery>();
 

--- a/TEL_ProjectBus/WebAPI/Consumers/Budgets/GetBudgetsByProjectIdConsumer.cs
+++ b/TEL_ProjectBus/WebAPI/Consumers/Budgets/GetBudgetsByProjectIdConsumer.cs
@@ -6,16 +6,24 @@ namespace TEL_ProjectBus.WebAPI.Consumers.Budgets;
 
 public class GetBudgetsByProjectIdConsumer(ProjectService projectService, ILogger<GetBudgetsByProjectIdConsumer> logger) : IConsumer<GetBudgetsByProjectIdQuery>
 {
-	public async Task Consume(ConsumeContext<GetBudgetsByProjectIdQuery> context)
-	{
-		var query = context.Message;
-		var projectId = query.ProjectId;
-		var budgets = await projectService.GetProjectBudgetAsync(context.Message.ProjectId, context.CancellationToken);
-		await context.RespondAsync(new GetBudgetsByProjectIdResponse
-		{
-			IsSuccess = true,
-			Message = $"Budgets for project {projectId} retrieved successfully.",
-			Budgets = budgets,
-		});
-	}
+        public async Task Consume(ConsumeContext<GetBudgetsByProjectIdQuery> context)
+        {
+                var query = context.Message;
+
+                var (budgets, totalCount) = await projectService.GetProjectBudgetAsync(
+                        query.ProjectId,
+                        query.PageNumber,
+                        query.PageSize,
+                        context.CancellationToken);
+
+                await context.RespondAsync(new GetBudgetsByProjectIdResponse
+                {
+                        IsSuccess = true,
+                        Message = $"Budgets for project {query.ProjectId} retrieved successfully.",
+                        Items = budgets,
+                        TotalCount = totalCount,
+                        PageNumber = query.PageNumber,
+                        PageSize = query.PageSize,
+                });
+        }
 }

--- a/TEL_ProjectBus/WebAPI/Controllers/Budget/BudgetQueryController.cs
+++ b/TEL_ProjectBus/WebAPI/Controllers/Budget/BudgetQueryController.cs
@@ -19,11 +19,20 @@ public class BudgetQueryController(IRequestClient<GetBudgetsQuery> _getBudgetsCl
 	/// <summary>
 	/// Возвращает список строк бюджета проекта по указанному идентификатору.
 	/// </summary>
-	[HttpGet("projects/{projectId:int}/budgets")]
-	public async Task<IActionResult> GetByProjectId(int projectId)
-	{
-		var response = await _getBudgetsByProjectIdClient.GetResponse<GetBudgetsByProjectIdResponse>(
-			new GetBudgetsByProjectIdQuery { ProjectId = projectId }, timeout: TimeSpan.FromSeconds(30));
+        [HttpGet("projects/{projectId:int}/budgets")]
+        public async Task<IActionResult> GetByProjectId(
+                int projectId,
+                [FromQuery] int pageNumber = 1,
+                [FromQuery] int pageSize = 20)
+        {
+                var response = await _getBudgetsByProjectIdClient.GetResponse<GetBudgetsByProjectIdResponse>(
+                        new GetBudgetsByProjectIdQuery
+                        {
+                                ProjectId = projectId,
+                                PageNumber = pageNumber,
+                                PageSize = pageSize,
+                        },
+                        timeout: TimeSpan.FromSeconds(30));
 
 		return SendResponse(response);
 	}

--- a/TEL_ProjectBus/WebAPI/Messages/Queries/Budgets/GetBudgetsByProjectIdQuery.cs
+++ b/TEL_ProjectBus/WebAPI/Messages/Queries/Budgets/GetBudgetsByProjectIdQuery.cs
@@ -1,6 +1,8 @@
-﻿namespace TEL_ProjectBus.WebAPI.Messages.Queries.Budgets;
+namespace TEL_ProjectBus.WebAPI.Messages.Queries.Budgets;
 
 public record GetBudgetsByProjectIdQuery
 {
-	public int ProjectId { get; init; }
+    public int ProjectId { get; init; }
+    public int PageNumber { get; init; } = 1;
+    public int PageSize { get; init; } = 20;
 }

--- a/TEL_ProjectBus/WebAPI/Messages/Queries/Budgets/GetBudgetsByProjectIdResponse.cs
+++ b/TEL_ProjectBus/WebAPI/Messages/Queries/Budgets/GetBudgetsByProjectIdResponse.cs
@@ -1,10 +1,12 @@
-﻿using TEL_ProjectBus.BLL.DTOs;
+using TEL_ProjectBus.BLL.DTOs;
 using TEL_ProjectBus.WebAPI.Common;
 
 namespace TEL_ProjectBus.WebAPI.Messages.Queries.Budgets;
 
 public record GetBudgetsByProjectIdResponse : ResponseBase
 {
-	public List<BudgetLineDto> Budgets { get; init; } = new();
-	public int TotalCount => Budgets.Count();
+    public IEnumerable<BudgetLineDto> Items { get; init; } = new List<BudgetLineDto>();
+    public int TotalCount { get; init; }
+    public int PageNumber { get; init; }
+    public int PageSize { get; init; }
 }


### PR DESCRIPTION
## Summary
- implement paging fields in `GetBudgetsByProjectIdQuery`
- extend `GetBudgetsByProjectIdResponse` with paging info
- support pagination in `ProjectService.GetProjectBudgetAsync`
- update `GetBudgetsByProjectIdConsumer` to return paged data
- allow controller to pass page parameters
- register request client for new query